### PR TITLE
changed a variable name in order to fix bug

### DIFF
--- a/server/songBuilder/hasher.js
+++ b/server/songBuilder/hasher.js
@@ -12,7 +12,7 @@ module.exports = {
       if (err) console.error(err);
 
       if (response === null) {
-        callback(temp);
+        callback(url_hash);
       } else {
         module.exports.createHash(str+'new', callback);
       }


### PR DESCRIPTION
i had forgotten to change the previous variable name: it should work now.

post requests to /create return an object with a proper hash id on it