### PR TITLE
connected routes for /:id

### DIFF
--- a/server/routes/listenHandler.js
+++ b/server/routes/listenHandler.js
@@ -10,14 +10,18 @@ var path = require('path');
 module.exports = {
   
   render : function (req, res){ 
-    
+    console.log('id', req.params.id);
     songCtrl.get({ hash_id : req.params.id }, function(err, response) {
       if (err) console.log(err);
 
       var template = fs.readFileSync(path.join(__dirname, '../Mustache/template.html'),'utf-8', function(err, data) {
         if (err) console.log(err);
       });
-      console.log('response', response);
+
+      if (response === null) {
+        res.status(404).send('Sorry cant find that url!');
+      }
+
       var templateObj = {
         title : response.title,
         artist : response.artist,
@@ -44,7 +48,7 @@ module.exports = {
       {title:"Hello",
       artist:"Adele",
       album_art:"http://images.musictimes.com/data/images/full/47589/adele-25-album-artwork.jpg?w=775", 
-      hash_id:1,
+      hash_id: '1',
       spotify_id : "spotify:track:0ENSn4fwAbCGeFGVUbXEU3",
       youtube_id : "https://www.youtube.com/watch?v=YQHsXMglC9A",
       itunes_id : "https://itun.es/us/sSXQ-?i=1051400980"}, function(err, response){

--- a/server/routes/routes.js
+++ b/server/routes/routes.js
@@ -25,6 +25,7 @@ module.exports = function (router) {
     res.sendFile(path.resolve('client/index.html'));
   });
 
-  router.get('/test/:id', listenHandler.render);// test2/:id should be changed to :id, where id is the req.param that identifies the song id in the database
+  router.get('/:id', listenHandler.render);
+
   router.post('/test', listenHandler.test); //for adding data for testing
 };


### PR DESCRIPTION
a new route for /:id in order to get song pages, also adjusted listenerhandler's render function to return a 404 if the url_hash was not found in the database. Otherwise it will send the html templated with the object data
