### PR TITLE
dbCrawl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist/
 *.css
 *.css.*
 .sass-cache
+dbCrawlLog.csv

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -20,15 +20,23 @@ module.exports = function(grunt) {
           'dist/styles/main-min.css': 'server/static/styles/main.css'
         }
       }
+    },
+    shell: {
+      mongo: {
+        command: "mongoexport --db songlink --collection songs --query \
+        '{ $or: [ {itunes_id: null}, {spotify_id: null}, {youtube_id: null} ] }' \
+        --out dbCrawlLog.csv --type=csv --fields 'hash_id,title,artist,album_title,youtube_id,spotify_id,itunes_id'"
+      }
     }
-
   });
 
   // Load the plugin that provides the "uglify" task.
   grunt.loadNpmTasks('grunt-contrib-uglify');
   grunt.loadNpmTasks('grunt-contrib-cssmin');
+  grunt.loadNpmTasks('grunt-shell');
 
   // Default task(s).
   grunt.registerTask('mini', ['uglify','cssmin']);
+  grunt.registerTask('dbCrawl', ['shell:mongo']);
 
 };

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "preserve": "rm -f dist/bundle.js && rm -f dist/app.css",
     "preserve:prod": "npm run build",
     "serve:prod": "NODE_ENV=production nodemon --debug server/server.js --ignore components --ignore containers",
-    "test": "NODE_ENV=production mocha test/models test/controllers test/server"
+    "test": "NODE_ENV=production mocha test/models test/controllers test/server",
+    "dbCrawl": "grunt dbCrawl"
   },
   "dependencies": {
     "babel-core": "^5.8.3",
@@ -37,11 +38,12 @@
     "css-loader": "^0.23.0",
     "dotenv": "^1.2.0",
     "express": "^4.13.3",
+    "extract-text-webpack-plugin": "^0.9.1",
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",
     "grunt-contrib-cssmin": "^0.14.0",
     "grunt-contrib-uglify": "^0.11.0",
-    "extract-text-webpack-plugin": "^0.9.1",
+    "grunt-shell": "^1.1.2",
     "history": "^1.13.1",
     "ituner": "^0.1.4",
     "jquery": "^2.1.4",


### PR DESCRIPTION
added a grunt task that runs on an npm script (dbCrawl) to crawl database for songs with an unknown [provider]_id, exports data to a csv file dbCrawlLog.csv, which has been added to gitignore