### PR TITLE
fixed bug where itunes was passing in too complicated of an object

### DIFF
--- a/server/handlers/appPage.js
+++ b/server/handlers/appPage.js
@@ -10,7 +10,7 @@ module.exports = {
 
 function create(req, res) {
 
-  var song = req.body;
+  var song = req.body.spotify_id ? {spotify_id : req.body.spotify_id} : {itunes_id : req.body.itunes_id};
 
   utils.checkDb(song, function (err, songFromDb) {
     if (songFromDb) {


### PR DESCRIPTION
added a ternary operator that searches for a spotify_id and defaults to itunes_id:
builds an object for DB to search for